### PR TITLE
Support `.boot` extension

### DIFF
--- a/clojure-quick-repls.el
+++ b/clojure-quick-repls.el
@@ -119,7 +119,7 @@
     (if (and (clojure-quick-repls-bound-truthy-p 'clojure-quick-repls-clj-con-buf)
              (clojure-quick-repls-bound-truthy-p 'clojure-quick-repls-cljs-con-buf)
              ext
-             (or (string= ext "clj") (string= ext "cljs")))
+             (or (string= ext "clj") (string= ext "boot") (string= ext "cljs")))
         (progn
           (if (string= ext "cljs")
               (nrepl-make-connection-default clojure-quick-repls-cljs-con-buf)


### PR DESCRIPTION
Nice work on this plugin! Now that `cider` has `boot` support ([#920](https://github.com/clojure-emacs/cider/issues/920)), I find `cider-quick-repls` is a nice, lightweight way to manage build process and exploratory programming from within emacs. In order to avoid conflict with existing project files (I'm guessing here), `boot` uses a `.boot` file extension. Can you please add support for this, so that `cider-switch-to-relevant-repl-buffer` will work from `build.boot`?
